### PR TITLE
Bump eventree to 0.7.0

### DIFF
--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -874,8 +874,9 @@ fn token<Node: AstNode, Token: AstToken>(node: Node, tree: &SyntaxTree) -> Optio
 #[cfg(test)]
 mod tests {
     use super::*;
+    use syntax::SyntaxTreeBuf;
 
-    fn parse(input: &str) -> (SyntaxTree, Root) {
+    fn parse(input: &str) -> (SyntaxTreeBuf, Root) {
         let parse = parser::parse_repl_line(&lexer::lex(input), input);
         for error in parse.errors() {
             println!("Syntax Error: {:?}", error);

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -14,7 +14,7 @@ pub use error::*;
 
 use crate::parser::Parser;
 use sink::Sink;
-use syntax::SyntaxTree;
+use syntax::{SyntaxTree, SyntaxTreeBuf};
 use token::Tokens;
 
 pub fn parse_source_file(tokens: &Tokens, input: &str) -> Parse {
@@ -28,7 +28,7 @@ pub fn parse_repl_line(tokens: &Tokens, input: &str) -> Parse {
 }
 
 pub struct Parse {
-    syntax_tree: SyntaxTree,
+    syntax_tree: SyntaxTreeBuf,
     errors: Vec<SyntaxError>,
 }
 
@@ -37,7 +37,7 @@ impl Parse {
         &self.syntax_tree
     }
 
-    pub fn into_syntax_tree(self) -> SyntaxTree {
+    pub fn into_syntax_tree(self) -> SyntaxTreeBuf {
         self.syntax_tree
     }
 

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eventree = "0.6.0"
+eventree = "0.7.0"
 capy_macros = {path = "../capy_macros"}

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -5,14 +5,31 @@ pub type SyntaxElement = eventree::SyntaxElement<TreeConfig>;
 pub type SyntaxNode = eventree::SyntaxNode<TreeConfig>;
 pub type SyntaxToken = eventree::SyntaxToken<TreeConfig>;
 pub type SyntaxTree = eventree::SyntaxTree<TreeConfig>;
+pub type SyntaxTreeBuf = eventree::SyntaxTreeBuf<TreeConfig>;
 pub type Event = eventree::Event<TreeConfig>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TreeConfig {}
 
-impl eventree::TreeConfig for TreeConfig {
+unsafe impl eventree::TreeConfig for TreeConfig {
     type NodeKind = NodeKind;
     type TokenKind = TokenKind;
+
+    fn node_kind_to_raw(node_kind: Self::NodeKind) -> u16 {
+        node_kind as u16
+    }
+
+    fn token_kind_to_raw(token_kind: Self::TokenKind) -> u16 {
+        token_kind as u16
+    }
+
+    unsafe fn token_kind_from_raw(raw: u16) -> Self::TokenKind {
+        mem::transmute(raw as u8)
+    }
+
+    unsafe fn node_kind_from_raw(raw: u16) -> Self::NodeKind {
+        mem::transmute(raw as u8)
+    }
 }
 
 capy_macros::define_token_enum! {
@@ -71,24 +88,4 @@ pub enum NodeKind {
     Path,
     Comment,
     Error,
-}
-
-unsafe impl eventree::SyntaxKind for TokenKind {
-    fn to_raw(self) -> u16 {
-        self as u16
-    }
-
-    unsafe fn from_raw(raw: u16) -> Self {
-        mem::transmute(raw as u8)
-    }
-}
-
-unsafe impl eventree::SyntaxKind for NodeKind {
-    fn to_raw(self) -> u16 {
-        self as u16
-    }
-
-    unsafe fn from_raw(raw: u16) -> Self {
-        mem::transmute(raw as u8)
-    }
 }


### PR DESCRIPTION
eventree 0.7.0:

- the `SyntaxKind` trait has been eliminated in favor of a few more methods on `TreeConfig`
- `&SyntaxTree` is now a direct pointer to the syntax tree’s data, rather than a pointer to a pointer. In order to accomplish this, `SyntaxTree` is now an unsized type and a new type `SyntaxTreeBuf` is introduced to own the allocation. `&SyntaxTree` and `SyntaxTreeBuf` have the same relationship as e.g. `&str` and `String` or `&Path` and `PathBuf`.
- the tree no longer stores *finish node* events explicitly, which sometimes gives a small perf boost