### PR TITLE
fix varios memory corruption bugs in `core/src/structs/list.capy`

### DIFF
--- a/core/src/libc.capy
+++ b/core/src/libc.capy
@@ -9,6 +9,9 @@ calloc :: (len: usize, size: usize) -> ^mut any extern;
 free :: (ptr: ^any) extern;
 // reallocates already allocated memory
 realloc :: (ptr: ^mut any, size: usize) -> ^mut any extern;
+// The reallocarray() function changes the size of (and possibly moves) the memory block pointed to by ptr
+// to be large enough for an array of nmemb elements, each of which is size bytes
+reallocarray :: (ptr: ^mut any, nmemb: usize, size: usize) -> ^mut any extern;
 // copies len bytes from dst to src
 memcpy :: (dst: ^mut any, src: ^any, len: usize) extern;
 

--- a/core/src/libc.capy
+++ b/core/src/libc.capy
@@ -9,9 +9,6 @@ calloc :: (len: usize, size: usize) -> ^mut any extern;
 free :: (ptr: ^any) extern;
 // reallocates already allocated memory
 realloc :: (ptr: ^mut any, size: usize) -> ^mut any extern;
-// The reallocarray() function changes the size of (and possibly moves) the memory block pointed to by ptr
-// to be large enough for an array of nmemb elements, each of which is size bytes
-reallocarray :: (ptr: ^mut any, nmemb: usize, size: usize) -> ^mut any extern;
 // copies len bytes from dst to src
 memcpy :: (dst: ^mut any, src: ^any, len: usize) extern;
 

--- a/core/src/structs/list.capy
+++ b/core/src/structs/list.capy
@@ -22,7 +22,7 @@ make :: (ty: type) -> List {
 make_with_capacity :: (ty: type, cap: usize) -> List {
     if cap == 0 { return make(ty); }
 
-    buf := libc.malloc(cap) as ^mut char;
+    buf := libc.malloc(cap * core.meta.stride_of(ty)) as ^mut char;
 
     if cap > 0 && ptr.is_null(buf) {
         core.panic_with("Error allocating the List");
@@ -113,7 +113,10 @@ _grow_by :: (list: ^mut List, len: usize) {
 
         ty_stride := core.meta.stride_of(list.ty);
 
-        list.buf = libc.realloc(list.buf, new_cap * ty_stride) as ^mut char;
+        list.buf = libc.reallocarray(list.buf, new_cap, ty_stride) as ^mut char;
+	if core.ptr.is_null(list.buf) {
+	    core.panic_with("failed to reallocate list");
+	}
         list.cap = new_cap;
     }
 }

--- a/core/src/structs/list.capy
+++ b/core/src/structs/list.capy
@@ -119,10 +119,13 @@ _grow_by :: (list: ^mut List, len: usize) {
 
         ty_stride := core.meta.stride_of(list.ty);
 
-        list.buf = libc.reallocarray(list.buf, new_cap, ty_stride) as ^mut char;
-	if core.ptr.is_null(list.buf) {
-	    core.panic_with("failed to reallocate list");
+	new_cap_raw = new_cap * ty_stride;
+
+	if new_cap_raw < new_cap || new_cap_raw < ty_stride {
+	    core.panic_with("overflow when trying to grow list");
 	}
+	
+        list.buf = libc.realloc(list.buf, new_cap_raw) as ^mut char;
         list.cap = new_cap;
     }
 }

--- a/core/src/structs/list.capy
+++ b/core/src/structs/list.capy
@@ -22,7 +22,13 @@ make :: (ty: type) -> List {
 make_with_capacity :: (ty: type, cap: usize) -> List {
     if cap == 0 { return make(ty); }
 
-    buf := libc.malloc(cap * core.meta.stride_of(ty)) as ^mut char;
+    raw_cap :: cap * core.meta.stride_of(ty);
+
+    if raw_cap < cap || raw_cap < core.meta.stride_of(ty) {
+        core.panic_with("overflow when trying to allocate the backing array of a list");
+    }
+
+    buf := libc.malloc(raw_cap) as ^mut char;
 
     if cap > 0 && ptr.is_null(buf) {
         core.panic_with("Error allocating the List");

--- a/core/src/structs/list.capy
+++ b/core/src/structs/list.capy
@@ -119,7 +119,7 @@ _grow_by :: (list: ^mut List, len: usize) {
 
         ty_stride := core.meta.stride_of(list.ty);
 
-	new_cap_raw = new_cap * ty_stride;
+	new_cap_raw :: new_cap * ty_stride;
 
 	if new_cap_raw < new_cap || new_cap_raw < ty_stride {
 	    core.panic_with("overflow when trying to grow list");


### PR DESCRIPTION
- bug 1: overflowing arithmetic when reallocting lists led to lists with wrong capacities
- bug 2: make_with_capacity() didn't use the passed type's stride