### PR TITLE
fix potential infinite loop in `string_builder` and `list`

### DIFF
--- a/core/src/math.capy
+++ b/core/src/math.capy
@@ -71,6 +71,23 @@ min_usize :: (x: usize, y: usize) -> usize {
     }
 }
 
+next_pow_of_two :: (x: usize) -> usize {
+    // see https://stackoverflow.com/questions/1322510/given-an-integer-how-do-i-find-the-next-largest-power-of-two-using-bit-twiddlin/1322548#1322548 
+    // for an explanation of how this works
+    x := x - 1;
+
+    x = x | {x >> 1};
+    x = x | {x >> 2};
+    x = x | {x >> 4};
+    x = x | {x >> 8};
+    x = x | {x >> 16};
+    x = x | {x >> 32};
+    x = x | {x >> 64}; // for platforms with a register width of 128
+                       // for other platforms this should compile down to a nop
+
+    x + 1
+}
+
 is_NaN :: (n: f64) -> bool {
     n != n
 }

--- a/core/src/structs/list.capy
+++ b/core/src/structs/list.capy
@@ -113,9 +113,10 @@ to_slice :: (list: ^List) -> [] any {
 _grow_by :: (list: ^mut List, len: usize) {
     if list.len + len > list.cap {
         new_cap := math.max_usize(list.cap * 2, 1);
-        while new_cap <= list.len + len {
-            new_cap = new_cap * 2;
-        }
+        new_cap = math.max_usize(
+	                         math.next_pow_of_two(list.len + len), 
+				 new_cap
+				 );
 
         ty_stride := core.meta.stride_of(list.ty);
 

--- a/core/src/structs/string_builder.capy
+++ b/core/src/structs/string_builder.capy
@@ -56,9 +56,10 @@ shrink_to_fit :: (self: ^mut StringBuilder) {
 _grow_by :: (self: ^mut StringBuilder, len: usize) {
     if self.len + len > self.cap {
         new_cap := math.max_usize(self.cap * 2, 1);
-        while new_cap <= self.len + len {
-            new_cap = new_cap * 2;
-        }
+        new_cap = math.max_usize(
+	                        math.next_pow_of_two(list.len + len), 
+				new_cap
+				);
 
         self.buf = libc.realloc(self.buf, new_cap) as ^mut char;
         self.cap = new_cap;

--- a/core/src/structs/string_builder.capy
+++ b/core/src/structs/string_builder.capy
@@ -57,7 +57,7 @@ _grow_by :: (self: ^mut StringBuilder, len: usize) {
     if self.len + len > self.cap {
         new_cap := math.max_usize(self.cap * 2, 1);
         new_cap = math.max_usize(
-	                        math.next_pow_of_two(list.len + len), 
+	                        math.next_pow_of_two(self.len + len), 
 				new_cap
 				);
 


### PR DESCRIPTION


this would happen if the minimum length requested by the `_grow_by`
function was the highest power of 2 a `usize` could store.
So i.e. if a usize was 8bits of length you could have:
```c
new_cap = 1;
while new_cap <= `0b10000000` {
	new_cap = new_cap << 1; // the highest new_cap can reach here is
				// 0b10000000 since anything higher overflows to 0
				// thus never not satisfying the loop condition and infinitely looping
}
```