### PR TITLE
fix potential segfault in `core.str_eq`

### DIFF
--- a/core/src/mod.capy
+++ b/core/src/mod.capy
@@ -418,7 +418,9 @@ str_eq :: (first: str, second: str) -> bool {
             return false;
         }
 
-        if first_ch == 0 { break; }
+        if first_ch == 0 || second_ch == 0 { 
+	    return first_ch == second_ch;
+	}
 
         idx = idx + 1;
     }


### PR DESCRIPTION
this would have happened if `length(first) > length(second)`