### PR TITLE
make capy tell cranelift about whether parameters are structs passed indirectly

### DIFF
--- a/crates/codegen/src/compiler/comptime.rs
+++ b/crates/codegen/src/compiler/comptime.rs
@@ -285,7 +285,7 @@ pub fn eval_comptime_blocks<'a>(
 
                 results.insert(ctc, result);
             }
-            FinalTy::Pointer(_) => {
+            FinalTy::Pointer { .. } => {
                 let layout = Layout::from_size_align(size as usize, std::mem::align_of::<u8>())
                     .expect("Invalid layout");
                 let raw = unsafe { std::alloc::alloc(layout) };

--- a/crates/codegen/src/compiler/functions.rs
+++ b/crates/codegen/src/compiler/functions.rs
@@ -127,7 +127,7 @@ impl FunctionCompiler<'_> {
             let param_ty = param_tys[old_idx as usize];
             if param_ty.is_aggregate() {
                 // TODO: this most likely oveshoots the abi align on some architectures
-                const ABI_ALIGN_MASK: u32 = 8 - 1;
+                const ABI_ALIGN_MASK: u32 = 16 - 1;
 
                 let stack_slot = self.builder.create_sized_stack_slot(StackSlotData {
                     kind: StackSlotKind::ExplicitSlot,
@@ -581,7 +581,7 @@ impl FunctionCompiler<'_> {
                 let value = self.world_bodies[self.file_name][local_def].value;
 
                 // TODO: this most likely oveshoots the abi align on some architectures
-                const ABI_ALIGN_MASK: u32 = 8 - 1;
+                const ABI_ALIGN_MASK: u32 = 16 - 1;
 
                 let stack_slot = self.builder.create_sized_stack_slot(StackSlotData {
                     kind: StackSlotKind::ExplicitSlot,
@@ -921,7 +921,7 @@ impl FunctionCompiler<'_> {
 
                 let (_, sub_ty) = ty.as_array().expect("array literals must have array types");
                 // TODO: this most likely oveshoots the abi align on some architectures
-                const ABI_ALIGN_MASK: u32 = 8 - 1;              
+                const ABI_ALIGN_MASK: u32 = 16 - 1;
                 let stack_slot = self.builder.create_sized_stack_slot(StackSlotData {
                     kind: StackSlotKind::ExplicitSlot,
                     size: (ty.stride() + ABI_ALIGN_MASK) & !ABI_ALIGN_MASK,
@@ -1061,7 +1061,7 @@ impl FunctionCompiler<'_> {
 
                     // println!("{:?} = {inner_size}", self.tys[self.fqn.module][expr]);
                     // TODO: this most likely oveshoots the abi align on some architectures
-                    const ABI_ALIGN_MASK: u32 = 8 - 1;
+                    const ABI_ALIGN_MASK: u32 = 16 - 1;
 
                     let stack_slot = self.builder.create_sized_stack_slot(StackSlotData {
                         kind: StackSlotKind::ExplicitSlot,
@@ -1327,7 +1327,7 @@ impl FunctionCompiler<'_> {
                 let ret_addr = if return_ty.is_aggregate() {
                     let aggregate_size = return_ty.size();
                     // TODO: this most likely oveshoots the abi align on some architectures
-                    const ABI_ALIGN_MASK: u32 = 8 - 1;
+                    const ABI_ALIGN_MASK: u32 = 16 - 1;
 
                     let stack_slot = self.builder.create_sized_stack_slot(StackSlotData {
                         kind: StackSlotKind::ExplicitSlot,
@@ -1822,13 +1822,13 @@ impl FunctionCompiler<'_> {
             } => {
                 let ty = self.tys[self.file_name][expr];
 
-                                // TODO: this most likely oveshoots the abi align on some architectures
-                                const ABI_ALIGN_MASK: u32 = 8 - 1;
+                // TODO: this most likely oveshoots the abi align on some architectures
+                const ABI_ALIGN_MASK: u32 = 16 - 1;
 
-                                let stack_slot = self.builder.create_sized_stack_slot(StackSlotData {
-                                    kind: StackSlotKind::ExplicitSlot,
-                                    size: (ty.stride() + ABI_ALIGN_MASK) & !ABI_ALIGN_MASK,
-                                });
+                let stack_slot = self.builder.create_sized_stack_slot(StackSlotData {
+                    kind: StackSlotKind::ExplicitSlot,
+                    size: (ty.stride() + ABI_ALIGN_MASK) & !ABI_ALIGN_MASK,
+                });
 
                 let memory = MemoryLoc::from_stack(stack_slot, 0, &mut self.builder, self.ptr_ty);
 

--- a/crates/codegen/src/compiler/functions.rs
+++ b/crates/codegen/src/compiler/functions.rs
@@ -126,10 +126,12 @@ impl FunctionCompiler<'_> {
             let param_ty = param_tys[old_idx as usize];
             if param_ty.is_aggregate() {
                 let size = param_ty.size();
+                // TODO: this most likely oveshoots the abi align on some architectures
+                const ABI_ALIGN_MASK: u32 = 8 - 1;
 
                 let stack_slot = self.builder.create_sized_stack_slot(StackSlotData {
                     kind: StackSlotKind::ExplicitSlot,
-                    size,
+                    size: (param_ty.stride() + ABI_ALIGN_MASK) & !ABI_ALIGN_MASK,
                 });
 
                 let stack_slot_addr = self.builder.ins().stack_addr(self.ptr_ty, stack_slot, 0);
@@ -559,10 +561,12 @@ impl FunctionCompiler<'_> {
                 let value = self.world_bodies[self.file_name][local_def].value;
 
                 let size = ty.size();
+                // TODO: this most likely oveshoots the abi align on some architectures
+                const ABI_ALIGN_MASK: u32 = 8 - 1;
 
                 let stack_slot = self.builder.create_sized_stack_slot(StackSlotData {
                     kind: StackSlotKind::ExplicitSlot,
-                    size,
+                    size: (ty.stride() + ABI_ALIGN_MASK) & !ABI_ALIGN_MASK,
                 });
 
                 let stack_addr = self.builder.ins().stack_addr(self.ptr_ty, stack_slot, 0);
@@ -785,10 +789,12 @@ impl FunctionCompiler<'_> {
                     return;
                 };
                 let array_size = sub_ty.stride() * items.len() as u32;
+                // TODO: this most likely oveshoots the abi align on some architectures
+                const ABI_ALIGN_MASK: u32 = 8 - 1;
 
                 let array_slot = self.builder.create_sized_stack_slot(StackSlotData {
                     kind: StackSlotKind::ExplicitSlot,
-                    size: array_size,
+                    size: (array_size + ABI_ALIGN_MASK) & !ABI_ALIGN_MASK,
                 });
 
                 let array_addr = self.builder.ins().stack_addr(self.ptr_ty, array_slot, 0);
@@ -957,10 +963,12 @@ impl FunctionCompiler<'_> {
                 } else {
                     ty.size()
                 };
+                // TODO: this most likely oveshoots the abi align on some architectures
+                const ABI_ALIGN_MASK: u32 = 8 - 1;
 
                 let stack_slot = self.builder.create_sized_stack_slot(StackSlotData {
                     kind: StackSlotKind::ExplicitSlot,
-                    size: array_size,
+                    size: (array_size + ABI_ALIGN_MASK) & !ABI_ALIGN_MASK,
                 });
 
                 let stack_addr = self.builder.ins().stack_addr(self.ptr_ty, stack_slot, 0);
@@ -1118,10 +1126,12 @@ impl FunctionCompiler<'_> {
                     let inner_size = self.tys[self.file_name][expr].size();
 
                     // println!("{:?} = {inner_size}", self.tys[self.fqn.module][expr]);
+                    // TODO: this most likely oveshoots the abi align on some architectures
+                    const ABI_ALIGN_MASK: u32 = 8 - 1;
 
                     let stack_slot = self.builder.create_sized_stack_slot(StackSlotData {
                         kind: StackSlotKind::ExplicitSlot,
-                        size: inner_size,
+                        size: (inner_size + ABI_ALIGN_MASK) & !ABI_ALIGN_MASK,
                     });
 
                     let expr = self.compile_expr(expr).unwrap();
@@ -1382,10 +1392,12 @@ impl FunctionCompiler<'_> {
 
                 let ret_addr = if return_ty.is_aggregate() {
                     let aggregate_size = return_ty.size();
+                    // TODO: this most likely oveshoots the abi align on some architectures
+                    const ABI_ALIGN_MASK: u32 = 8 - 1;
 
                     let stack_slot = self.builder.create_sized_stack_slot(StackSlotData {
                         kind: StackSlotKind::ExplicitSlot,
-                        size: aggregate_size,
+                        size: (aggregate_size + ABI_ALIGN_MASK) & !ABI_ALIGN_MASK,
                     });
                     let stack_slot_addr = self.builder.ins().stack_addr(self.ptr_ty, stack_slot, 0);
 
@@ -1876,10 +1888,13 @@ impl FunctionCompiler<'_> {
             } => {
                 let ty = self.tys[self.file_name][expr];
 
-                let stack_slot = self.builder.create_sized_stack_slot(StackSlotData {
-                    kind: StackSlotKind::ExplicitSlot,
-                    size: ty.size(),
-                });
+                                // TODO: this most likely oveshoots the abi align on some architectures
+                                const ABI_ALIGN_MASK: u32 = 8 - 1;
+
+                                let stack_slot = self.builder.create_sized_stack_slot(StackSlotData {
+                                    kind: StackSlotKind::ExplicitSlot,
+                                    size: (ty.stride() + ABI_ALIGN_MASK) & !ABI_ALIGN_MASK,
+                                });
 
                 let stack_addr = self.builder.ins().stack_addr(self.ptr_ty, stack_slot, 0);
 

--- a/crates/codegen/src/compiler/mod.rs
+++ b/crates/codegen/src/compiler/mod.rs
@@ -1075,6 +1075,14 @@ impl MemoryLoc {
         }
     }
 
+    /// This converts a value into a `MemoryLoc` with 0 offset
+    fn from_value(val: Value) -> Self {
+        Self {
+            addr: val,
+            offset: 0,
+        }
+    }
+
     /// Does a simple store of a memmove if necessary
     ///
     /// By using this function, you promise that the bytes of val can fit inside
@@ -1112,6 +1120,12 @@ impl MemoryLoc {
                 .ins()
                 .store(MemFlags::trusted(), val, self.addr, self.offset as i32);
         }
+    }
+
+    /// store the given `Value` to the given `MemoryLoc`
+    fn store(&self, val: Value, builder: &mut FunctionBuilder) {
+        let addr = self.into_value(builder);
+        builder.ins().store(MemFlags::trusted(), val, addr, 0);
     }
 }
 

--- a/crates/codegen/src/convert.rs
+++ b/crates/codegen/src/convert.rs
@@ -243,7 +243,7 @@ fn calc_single(ty: Intern<Ty>, ptr_ty: types::Type) {
         },
         hir_ty::Ty::Array { sub_ty, .. } => {
             calc_single(*sub_ty, ptr_ty);
-            let mask = ptr_ty.bytes() - 1;
+            let mask = 16 - 1;
             FinalTy::Pointer {
                 ty: ptr_ty,
                 aggr_pointee_size: Some((ty.stride() + mask) & !mask),
@@ -284,7 +284,7 @@ fn calc_single(ty: Intern<Ty>, ptr_ty: types::Type) {
             for (_, ty) in members {
                 calc_single(*ty, ptr_ty);
             }
-            let mask = ptr_ty.bytes() - 1;
+            let mask = 16 - 1;
             FinalTy::Pointer {
                 ty: ptr_ty,
                 aggr_pointee_size: Some((ty.stride() + mask) & !mask),

--- a/crates/codegen/src/convert.rs
+++ b/crates/codegen/src/convert.rs
@@ -90,7 +90,6 @@ impl FinalTy {
                 ty,
                 aggr_pointee_size: Some(sz),
             } => {
-                dbg!(sz);
                 Some(AbiParam::special(
                     ty,
                     ArgumentPurpose::StructArgument(sz as u32),

--- a/crates/codegen/src/convert.rs
+++ b/crates/codegen/src/convert.rs
@@ -242,7 +242,7 @@ fn calc_single(ty: Intern<Ty>, ptr_ty: types::Type) {
             calc_single(*sub_ty, ptr_ty);
             FinalTy::Pointer {
                 ty: ptr_ty,
-                aggr_pointee_size: Some(ty.stride().next_multiple_of(8)),
+                aggr_pointee_size: Some(ty.stride()),
             }
         }
         hir_ty::Ty::Slice { sub_ty, .. } => {
@@ -282,7 +282,7 @@ fn calc_single(ty: Intern<Ty>, ptr_ty: types::Type) {
             }
             FinalTy::Pointer {
                 ty: ptr_ty,
-                aggr_pointee_size: Some(ty.stride().next_multiple_of(8)),
+                aggr_pointee_size: Some(ty.stride()),
             }
         }
         hir_ty::Ty::Type => FinalTy::Number(NumberType {

--- a/crates/codegen/src/layout.rs
+++ b/crates/codegen/src/layout.rs
@@ -149,7 +149,7 @@ fn calc_single(ty: Intern<Ty>, pointer_bit_width: u32) {
         Ty::Bool | Ty::Char => 1, // bools and chars are u8's
         Ty::String | Ty::Pointer { .. } | Ty::Function { .. } => size,
         // the sub_ty was already `calc()`ed just before
-        Ty::Array { sub_ty, .. } => sub_ty.align().max(8),
+        Ty::Array { sub_ty, .. } => sub_ty.align(),
         Ty::Slice { .. } => size / 2,
         Ty::Distinct { sub_ty: ty, .. } => ty.align(),
         Ty::Struct { .. } => ty.struct_layout().unwrap().align,

--- a/crates/codegen/src/layout.rs
+++ b/crates/codegen/src/layout.rs
@@ -149,7 +149,7 @@ fn calc_single(ty: Intern<Ty>, pointer_bit_width: u32) {
         Ty::Bool | Ty::Char => 1, // bools and chars are u8's
         Ty::String | Ty::Pointer { .. } | Ty::Function { .. } => size,
         // the sub_ty was already `calc()`ed just before
-        Ty::Array { sub_ty, .. } => sub_ty.align(),
+        Ty::Array { sub_ty, .. } => sub_ty.align().max(8),
         Ty::Slice { .. } => size / 2,
         Ty::Distinct { sub_ty: ty, .. } => ty.align(),
         Ty::Struct { .. } => ty.struct_layout().unwrap().align,

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -1038,7 +1038,7 @@ mod tests {
                  ty =
                   BOOL
                  name = array
-                 offset = 16
+                 offset = 10
                  ty =
                   ARRAY
                   len = 3

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -91,6 +91,11 @@ pub fn compile_obj(
     let mut flag_builder = settings::builder();
     // flag_builder.set("use_colocated_libcalls", "false").unwrap();
     flag_builder.set("is_pic", "true").unwrap();
+    flag_builder.set("opt_level", "speed").unwrap();
+    flag_builder.set("enable_alias_analysis", "true").unwrap();
+    flag_builder.set("enable_pinned_reg", "true").unwrap();
+    flag_builder.set("enable_atomics", "true").unwrap();
+    flag_builder.set("enable_jump_tables", "true").unwrap();
 
     let isa_builder = isa::lookup(target).unwrap_or_else(|msg| {
         println!("invalid target: {}", msg);
@@ -1033,7 +1038,7 @@ mod tests {
                  ty =
                   BOOL
                  name = array
-                 offset = 10
+                 offset = 16
                  ty =
                   ARRAY
                   len = 3


### PR DESCRIPTION
This is a first step of making capy fully comply with the system v calling convention.

# open issues 

1. The sys v x64 spec states that
> The classification of aggregate (_structures and arrays_) and union types works
as follows: 1. If the size of an object is larger than four eightbytes, or it contains unaligned
fields, it has class MEMORY ...

This is why this commit treats arrays and structs as the same, even though the cranelift docs only mention structs (is this correct).

~2. alignment: this code currently artificially pretends that all structs/arrays are 8 byte aligned~
3. actually split the structures into their components if they are "[smaller] than four eightbytes"