### PR TITLE
inline small memcpys

### DIFF
--- a/crates/codegen/src/compiler/functions.rs
+++ b/crates/codegen/src/compiler/functions.rs
@@ -29,6 +29,8 @@ use super::{
     MetaTyLayoutArrays,
 };
 
+const MEMCPY_THREASHOLD: u64 = 64;
+
 struct UnfinishedComptimeErr;
 
 // represents a single block containing multiple defer statements
@@ -134,10 +136,27 @@ impl FunctionCompiler<'_> {
 
                 let stack_slot_addr = self.builder.ins().stack_addr(self.ptr_ty, stack_slot, 0);
 
-                let size = self.builder.ins().iconst(self.ptr_ty, size as i64);
+                if size > 32 {
+                    let size = self.builder.ins().iconst(self.ptr_ty, size as i64);
 
-                self.builder
-                    .call_memcpy(self.module.target_config(), stack_slot_addr, value, size);
+                    self.builder.call_memcpy(
+                        self.module.target_config(),
+                        stack_slot_addr,
+                        value,
+                        size,
+                    )
+                } else {
+                    self.builder.emit_small_memory_copy(
+                        self.module.target_config(),
+                        stack_slot_addr,
+                        value,
+                        param_ty.stride() as u64,
+                        param_ty.align() as u8,
+                        param_ty.align() as u8,
+                        true,
+                        MemFlags::trusted(),
+                    )
+                }
 
                 self.builder.def_var(var, stack_slot_addr);
             } else {
@@ -151,19 +170,7 @@ impl FunctionCompiler<'_> {
             Some(body) => {
                 if return_ty.is_aggregate() {
                     let dest = self.builder.use_var(dest_param.unwrap());
-
-                    let aggregate_size = return_ty.size();
-                    let aggregate_size = self
-                        .builder
-                        .ins()
-                        .iconst(self.ptr_ty, aggregate_size as i64);
-
-                    self.builder.call_memcpy(
-                        self.module.target_config(),
-                        dest,
-                        body,
-                        aggregate_size,
-                    );
+                    self.build_memcpy_ty(body, dest, return_ty, true);
 
                     self.builder.ins().return_(&[dest])
                 } else {
@@ -471,6 +478,47 @@ impl FunctionCompiler<'_> {
         self.create_global_data(&name, false, text.into_bytes().into_boxed_slice(), 1)
     }
 
+    fn build_memcpy_ty(&mut self, src: Value, dest: Value, ty: Intern<Ty>, non_overlapping: bool) {
+        let size = ty.size();
+        if size > (MEMCPY_THREASHOLD as u32) {
+            let size = self.builder.ins().iconst(self.ptr_ty, size as i64);
+
+            self.builder
+                .call_memcpy(self.module.target_config(), dest, src, size)
+        } else {
+            self.builder.emit_small_memory_copy(
+                self.module.target_config(),
+                dest,
+                src,
+                ty.stride() as u64,
+                ty.align() as u8,
+                ty.align() as u8,
+                non_overlapping,
+                MemFlags::trusted(),
+            )
+        }
+    }
+
+    fn build_memcpy_size(&mut self, src: Value, dest: Value, size: u64, non_overlapping: bool) {
+        if size > MEMCPY_THREASHOLD {
+            let size = self.builder.ins().iconst(self.ptr_ty, size as i64);
+
+            self.builder
+                .call_memcpy(self.module.target_config(), dest, src, size)
+        } else {
+            self.builder.emit_small_memory_copy(
+                self.module.target_config(),
+                dest,
+                src,
+                size,
+                1,
+                1,
+                non_overlapping,
+                MemFlags::trusted(),
+            )
+        }
+    }
+
     fn get_func_id(&mut self, fqn: hir::Fqn) -> FuncId {
         super::get_func_id(
             self.module,
@@ -754,10 +802,7 @@ impl FunctionCompiler<'_> {
                 let offset = self.builder.ins().iconst(self.ptr_ty, offset as i64);
                 let actual_addr = self.builder.ins().iadd(addr, offset);
 
-                let size = self.builder.ins().iconst(self.ptr_ty, expr_size as i64);
-
-                self.builder
-                    .call_memcpy(self.module.target_config(), actual_addr, value, size);
+                self.build_memcpy_size(value, actual_addr, expr_size as u64, false);
             } else {
                 self.builder
                     .ins()
@@ -820,14 +865,7 @@ impl FunctionCompiler<'_> {
 
                 let actual_addr = self.builder.ins().iadd(addr, offset);
 
-                let size = self.builder.ins().iconst(self.ptr_ty, expr_size as i64);
-
-                self.builder.call_memcpy(
-                    self.module.target_config(),
-                    actual_addr,
-                    far_off_thing,
-                    size,
-                )
+                self.build_memcpy_size(far_off_thing, actual_addr, expr_size as u64, false);
             }
             _ => {
                 if let Some(value) = self.compile_and_cast(expr, expected_ty) {


### PR DESCRIPTION
use cranelift's `emit_small_memory_copy` function when constructing memcpys off small values