### PR TITLE
fix unsingned integer formatting for large enough u64s

### DIFF
--- a/core/src/fmt.capy
+++ b/core/src/fmt.capy
@@ -23,13 +23,22 @@ i64_to_string :: (n: i64) -> StringBuilder {
 }
 
 u64_to_string :: (n: u64) -> StringBuilder {
-    str := string_builder.make_with_capacity(39);
-    
-    new_len := _write_i64_to_buf(n as i64, false, str.buf as ^mut any as ^mut u8, 0, 0);
+    n := n;
+    digits := core.math.lg_u64(n) + 1;
+    str := string_builder.make_with_capacity(digits);
+    str.len = digits;
 
-    str.len = new_len;
+    while digits > 0 {
+        remainder :: n % 10;
+        n         =  n / 10;
+        digits    =  digits - 1;
 
-    string_builder.shrink_to_fit(^mut str);
+        ptr.write(
+                  str.buf, 
+                  ('0' as u8 + remainder) as u8, 
+                  digits
+                );
+    }
 
     str
 }

--- a/core/src/math.capy
+++ b/core/src/math.capy
@@ -91,3 +91,39 @@ next_pow_of_two :: (x: usize) -> usize {
 is_NaN :: (n: f64) -> bool {
     n != n
 }
+
+// logarithm base 2 of unsigned 64 bit integers
+// TODO: use cranelift intrinsic for this
+// returns 0 if n == 0
+log2_u64 :: (n: u64) -> u64 {
+    n := n;
+    i := 0;
+    if n == 0 { return 0; }
+    while n != 1 {
+        n = n >> 1;
+        i = i + 1 as u64;
+    }
+    i
+}
+
+// logarithm base 10 of unsigned 64 bit integers
+// returns 0 if n == 0
+lg_u64 :: (n: u64) -> u64 {
+    pows_of_10 :: comptime {
+        arr : [20] u64;
+        i := 0;
+        pow := 1;
+        
+        while i <= 19 {
+            arr[i] = pow;
+            pow    = 10 * pow;
+            i      = i  + 1;
+        }
+
+        arr
+    };
+    if n == 0 { return 0; }
+
+    t :: (((log2_u64(n) + 1) * 1233) >> 12);
+    t - (n < pows_of_10[t]) as u64
+}


### PR DESCRIPTION
previously if you had a u64 with it's highest bit set, and tried to format it, you would go around all the sign removal logic in `_write_i64_to_buf`, thus getting negative remainders and confusing output.
The easiest way to circumvent this would have been to simply cast `n` into a u64 in the aforementioned function, but this pr also adds some math functions :D, and is imo more elegant.